### PR TITLE
ci: swap PAT for GitHub App token in tag-on-version-change workflow

### DIFF
--- a/.github/workflows/tag-on-version-change.yml
+++ b/.github/workflows/tag-on-version-change.yml
@@ -5,11 +5,22 @@ on:
       - master
 
 name: Create Git Tag
+
+permissions:
+  contents: write
+
 jobs:
   versioner:
     runs-on: ubuntu-latest
     steps:
+      - name: Mint release-app token
+        id: app-token
+        uses: actions/create-github-app-token@a8d616148505b5069dccd32f177bb87d7f39123b  # v2.0.6
+        with:
+          app-id: ${{ vars.RELEASE_APP_CLIENT_ID }}
+          private-key: ${{ secrets.RELEASE_APP_PRIVATE_KEY }}
+
       - name: Update Version
         uses: pterm/tag-action@main
         env:
-          ACCESS_TOKEN: ${{ secrets.REPO_ACCESS_TOKEN }}
+          ACCESS_TOKEN: ${{ steps.app-token.outputs.token }}


### PR DESCRIPTION
## Summary

- Replaces `secrets.REPO_ACCESS_TOKEN` (a long-lived personal access token) with a short-lived token minted by the shared org-wide GitHub App (`RELEASE_APP_CLIENT_ID` / `RELEASE_APP_PRIVATE_KEY`).
- Adds `actions/create-github-app-token@a8d616148505b5069dccd32f177bb87d7f39123b` (v2.0.6) as the token-mint step before `pterm/tag-action`.
- Adds explicit `permissions: contents: write` at the workflow level (required for tag pushes).

The app credentials are already provisioned org-wide (visibility=all) as an Actions variable and secret — no repository-level secret changes needed.

## Tokens deliberately left untouched

| Token | File | Reason |
|---|---|---|
| GoReleaser registry/publish tokens | `release.yml`, `release-test.yml` | Registry/publish auth; out of scope for this change |

## Test plan

- [ ] CI passes on this PR (no runtime execution of tag-action, but actionlint validated the workflow syntax locally — 0 errors)
- [ ] `secrets.REPO_ACCESS_TOKEN` is no longer referenced anywhere in `.github/workflows/`